### PR TITLE
Use sh-bang for proper execution on Linux/UNIX/MacOS, and add filespec sanity checks / error handling.

### DIFF
--- a/Intellivision/bin2ecs.py
+++ b/Intellivision/bin2ecs.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python3
 #
 # Tool to convert BIN+CFG pairs to an ECS file
 #
@@ -159,8 +160,13 @@ if (len(sys.argv) <= 1):
     print("Usage: BIN2ECS <filespec>")
 else:
     binFilesList = glob.glob(sys.argv[1])
+    if len(binFilesList) == 0:
+        print('filespec', sys.argv[1], 'does not match any files')
+        sys.exit(1)
     for name in binFilesList:
         if name.lower().endswith(".bin"):
             parsebin(name)
+        else:
+            print('filespec', name, 'does not end with .bin and will not be processed')
 if getattr(sys, 'frozen', False):
     input("Press enter to proceed...")

--- a/Intellivision/bin2ecs.py
+++ b/Intellivision/bin2ecs.py
@@ -167,6 +167,6 @@ else:
         if name.lower().endswith(".bin"):
             parsebin(name)
         else:
-            print('filespec', name, 'does not end with .bin and will not be processed')
+            print('file', name, 'does not end with .bin and will not be processed')
 if getattr(sys, 'frozen', False):
     input("Press enter to proceed...")


### PR DESCRIPTION
Pretty much what it says on the tin.  Without a leading sh-bang, Linux/UNIX/MacOS will attempt to execute this script as shell, which naturally fails.

While I was here, I added a bit of error message handling around the glob routine so that it is more obvious how to use the tool.

Cheers :)